### PR TITLE
fix: count only immediate tests

### DIFF
--- a/lib/utils/count.ts
+++ b/lib/utils/count.ts
@@ -5,9 +5,13 @@ export const getTotalCount = <Type extends TestHandler>(
 ): Count => {
   return testHandlers.reduce(
     (total, { getCount }) => {
+      const { failed } = getCount();
+      const passedIncrement = failed ? 0 : 1;
+      const failedIncrement = 1 - passedIncrement;
+
       return {
-        passed: total.passed + getCount().passed,
-        failed: total.failed + getCount().failed
+        passed: total.passed + passedIncrement,
+        failed: total.failed + failedIncrement
       };
     },
     { passed: 0, failed: 0 }


### PR DESCRIPTION
- Count immediate tests and not expectations.
- The total number of expectations under a test was counted as the total number of tests.
- Each level must count only the tests immediately below it.