### PR TITLE
Fix directory read

### DIFF
--- a/lib/run-tests/get-paths.ts
+++ b/lib/run-tests/get-paths.ts
@@ -8,7 +8,7 @@ const { readDir } = Deno;
 
 const matchFile =
   (regex: RegExp): FileMatcher =>
-  (path) => {
+  path => {
     return regex.test(path);
   };
 
@@ -122,12 +122,16 @@ export const getPaths = (isMatch: FileMatcher): PathGetter => {
       return paths;
     }
 
-    const dirEntries = readDir(path);
+    try {
+      const dirEntries = readDir(path);
 
-    for await (const entry of dirEntries) {
-      if (entry.isFile || entry.isDirectory) {
-        paths = await get(`${path}/${entry.name}`, paths);
+      for await (const entry of dirEntries) {
+        if (entry.isFile || entry.isDirectory) {
+          paths = await get(`${path}/${entry.name}`, paths);
+        }
       }
+    } catch (error) {
+      console.error(error);
     }
 
     return paths;


### PR DESCRIPTION
Fix the error arising from reading a path without a file extension as a directory path. This may be misleading as some files do not have file extensions. Also simplify hierarchy testing docs.