### PR TITLE
fix(get-paths): check type of path

### DIFF
--- a/lib/run-tests/get-paths.test.ts
+++ b/lib/run-tests/get-paths.test.ts
@@ -1,15 +1,33 @@
 import toBe from '../assertions/to-be/to-be.ts';
 import toEqual from '../assertions/to-equal/to-equal.ts';
+import toBeInstanceOf from '../assertions/to-be-instance-of/to-be-instance-of.ts';
 import { describe } from '../suite/suite.ts';
 import {
   type FileMatcher,
   getPaths,
   isTSFile,
   isJSFile,
-  isESFile
+  isESFile,
+  getPathType
 } from './get-paths.ts';
 
-describe('fileMatchers', (it) => {
+describe('getPathType', async it => {
+  const demoDir = new URL('demo', import.meta.url).pathname;
+
+  await it('should get path type for valid paths', async expect => {
+    const dirTypeResult = await getPathType(demoDir);
+    const fileTypeResult = await getPathType(`${demoDir}/expectation.test.ts`);
+    expect(dirTypeResult, toEqual('directory'));
+    expect(fileTypeResult, toEqual('file'));
+  });
+
+  await it('should return error for non-extent paths', async expect => {
+    const errorResult = await getPathType(`${demoDir}/non-extent-path`);
+    expect(errorResult, toBeInstanceOf(Error));
+  });
+});
+
+describe('fileMatchers', it => {
   const pairs: Array<[FileMatcher, Array<string>]> = [
     [isTSFile, ['ts', 'tsx']],
     [isJSFile, ['js', 'jsx', 'mjs', 'cjs']],
@@ -23,7 +41,7 @@ describe('fileMatchers', (it) => {
     const extensionList = extensions.join("', '");
     const description = `should match test files with extensions '${extensionList}'`;
 
-    it(description, (expect) => {
+    it(description, expect => {
       for (const prefix of prefixes) {
         for (const label of labels) {
           for (const ext of extensions) {
@@ -35,19 +53,17 @@ describe('fileMatchers', (it) => {
   });
 });
 
-describe('getPaths', async (it) => {
-  await it('should return all paths in demo directory', async (expect) => {
+describe('getPaths', async it => {
+  await it('should return all paths in demo directory', async expect => {
     const entry = new URL('demo', import.meta.url).pathname;
     const getTestPaths = getPaths(isTSFile);
     const paths = await getTestPaths(entry);
 
-    ['expectation', 'step', 'suite', 'module', 'package'].forEach(
-      (fileName) => {
-        expect(
-          paths.some((path) => path.endsWith(`${fileName}.test.ts`)),
-          toEqual(true)
-        );
-      }
-    );
+    ['expectation', 'step', 'suite', 'module', 'package'].forEach(fileName => {
+      expect(
+        paths.some(path => path.endsWith(`${fileName}.test.ts`)),
+        toEqual(true)
+      );
+    });
   });
 });


### PR DESCRIPTION
Check if path is for a file, directory or something else. Use Deno.stat to do the check. This is a more accurate approach than that used before.